### PR TITLE
Make name field optional

### DIFF
--- a/Sources/RCKML/Features/KMLFolder.swift
+++ b/Sources/RCKML/Features/KMLFolder.swift
@@ -13,12 +13,12 @@ import Foundation
 ///
 /// For reference, see [KML Spec](https://developers.google.com/kml/documentation/kmlreference#folder)
 public struct KMLFolder {
-    public var name: String
+    public var name: String?
     public var featureDescription: String?
     public var features: [KMLFeature]
 
     public init(
-        name: String,
+        name: String? = nil,
         featureDescription: String? = nil,
         features: [KMLFeature] = []
     ) {
@@ -37,7 +37,7 @@ extension KMLFolder: KmlElement {
 
     public init(xml: AEXMLElement) throws {
         try Self.verifyXmlTag(xml)
-        name = try Self.nameFromXml(xml)
+        name = Self.nameFromXml(xml)
         featureDescription = Self.descriptionFromXml(xml)
         features = try Self.features(from: xml)
     }

--- a/Sources/RCKML/Features/KMLPlacemark.swift
+++ b/Sources/RCKML/Features/KMLPlacemark.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// For reference, see [KML Spec](https://developers.google.com/kml/documentation/kmlreference#placemark)
 public struct KMLPlacemark {
-    public var name: String
+    public var name: String?
     public var featureDescription: String?
     public var geometry: KMLGeometry
 
@@ -44,7 +44,7 @@ extension KMLPlacemark: KmlElement {
 
     public init(xml: AEXMLElement) throws {
         try Self.verifyXmlTag(xml)
-        self.name = try Self.nameFromXml(xml)
+        self.name = Self.nameFromXml(xml)
         self.featureDescription = Self.descriptionFromXml(xml)
         guard let childGeometryType = KMLGeometryType.allCases.first(where: { xml[$0.rawValue].error == nil })
         else {

--- a/Sources/RCKML/Protocols/KMLFeature.swift
+++ b/Sources/RCKML/Protocols/KMLFeature.swift
@@ -12,8 +12,8 @@ import Foundation
 ///
 /// For definition, see [KML spec](https://developers.google.com/kml/documentation/kmlreference#feature)
 public protocol KMLFeature: KmlElement {
-    /// A user-visible name for the feature.
-    var name: String { get }
+    /// An optional user-visible name for the feature.
+    var name: String? { get }
 
     /// An optional text description of the feature.
     var featureDescription: String? { get }
@@ -23,13 +23,13 @@ public protocol KMLFeature: KmlElement {
 
 internal extension KMLFeature {
     /// Helper function for use when creating KMLFeature instances in `KmlFeature.init(xml:)`,
-    /// this function returns the required *name* attribute of the KML feature.
+    /// this function returns the optional *name* attribute of the KML feature.
     ///
     /// - Parameter xml: The XML element being used to create this KMLFeature
     /// - Throws: XML Error
     /// - Returns: Name value of the KML element.
-    static func nameFromXml(_ xml: AEXMLElement) throws -> String {
-        try xml.requiredXmlChild(name: "name").string
+    static func nameFromXml(_ xml: AEXMLElement) -> String? {
+        xml.optionalXmlChild(name: "name")?.string
     }
 
     /// Helper function for use when creating KMLFeature instances in `KmlFeature.init(xml:)`,


### PR DESCRIPTION
Name field seems to be optional according to the specification so parsing should not fail on trying to find a name child element.